### PR TITLE
Better conditions for `between`

### DIFF
--- a/Example/Tests/StringExtensionTests.swift
+++ b/Example/Tests/StringExtensionTests.swift
@@ -9,6 +9,8 @@ class SwiftStringTests: XCTestCase {
         assertThat("<a><a>foo</a></a>".between("<a>", "</a>"), presentAnd(equalTo("<a>foo</a>")))
         assertThat("<a>foo".between("<a>", "</a>"), nilValue())
         assertThat("Some strings } are very {weird}, dont you think?".between("{", "}"), presentAnd(equalTo("weird")))
+        assertThat("<a></a>".between("<a>", "</a>"), nilValue())
+        assertThat("<a>foo</a>".between("<a>", "<a>"), nilValue())
     }
     
     func testCamelize() {

--- a/Pod/Classes/StringExtensions.swift
+++ b/Pod/Classes/StringExtensions.swift
@@ -9,12 +9,21 @@
 import Foundation
 
 public extension String {
-    
+
+    ///  Finds the string between two bookend strings if it can be found.
+    ///
+    ///  - parameter left:  The left bookend
+    ///  - parameter right: The right bookend
+    ///
+    ///  - returns: The string between the two bookends, or nil if the bookends cannot be found, the bookends are the same or appear contiguously.
     func between(left: String, _ right: String) -> String? {
-        if let leftRange = rangeOfString(left), rightRange = rangeOfString(right, options: .BackwardsSearch) {
-            return self[leftRange.endIndex...rightRange.startIndex.predecessor()]
-        }
-        return nil
+        guard
+            let leftRange = rangeOfString(left), rightRange = rangeOfString(right, options: .BackwardsSearch)
+            where left != right && leftRange.endIndex != rightRange.startIndex
+            else { return nil }
+
+        return self[leftRange.endIndex...rightRange.startIndex.predecessor()]
+
     }
     
     // https://gist.github.com/stevenschobert/540dd33e828461916c11


### PR DESCRIPTION
Add documentation for `between` and handle the conditions where the two bookends are the same and the if there is no text between the bookends. Updated tests.
