### PR TITLE
Make camelize consistently use lower camel case

### DIFF
--- a/Pod/Classes/StringExtensions.swift
+++ b/Pod/Classes/StringExtensions.swift
@@ -28,12 +28,12 @@ public extension String {
     func camelize() -> String {
         let source = clean(" ", allOf: "-", "_")
         if source.characters.contains(" ") {
-            let first = source.substringToIndex(source.startIndex.advancedBy(1))
+            let first = source.substringToIndex(source.startIndex.advancedBy(1)).lowercaseString
             let cammel = NSString(format: "%@", (source as NSString).capitalizedString.stringByReplacingOccurrencesOfString(" ", withString: "", options: [], range: nil)) as String
             let rest = String(cammel.characters.dropFirst())
             return "\(first)\(rest)"
         } else {
-            let first = (source as NSString).lowercaseString.substringToIndex(source.startIndex.advancedBy(1))
+            let first = source.substringToIndex(source.startIndex.advancedBy(1)).lowercaseString
             let rest = String(source.characters.dropFirst())
             return "\(first)\(rest)"
         }


### PR DESCRIPTION
Looks like camelize was only ensuring that the first letter was lowercase when there was only one word. This applies does that for the multi-word case. I also removed an unnecessary cast to NSString and moved the call to `lowercaseString` to the end so that it only needs to be applied to the one character.
