### PR TITLE
Correct subscript functionality

### DIFF
--- a/Pod/Classes/StringExtensions.swift
+++ b/Pod/Classes/StringExtensions.swift
@@ -267,7 +267,7 @@ public extension String {
     subscript(r: Range<Int>) -> String {
         get {
             let startIndex = self.startIndex.advancedBy(r.startIndex)
-            let endIndex = self.startIndex.advancedBy(r.endIndex - r.startIndex)
+            let endIndex = self.startIndex.advancedBy(r.endIndex)
             return self[startIndex..<endIndex]
         }
     }


### PR DESCRIPTION
`"abcdefgh"[4..<8]` now yields `"efgh"`, as expected.
