### PR TITLE
Add new extension method rindexOf

### DIFF
--- a/Example/Tests/StringExtensionTests.swift
+++ b/Example/Tests/StringExtensionTests.swift
@@ -174,6 +174,12 @@ class SwiftStringTests: XCTestCase {
         assertThat("hi".times(3) == "hihihi")
         assertThat(" ".times(10) == "          ")
     }
+
+    func testFindSubstring() {
+        assertThat("hello-world-abc".findSubstring("\\w+\\-\\w+", ignoreCase: false) == "hello-world")
+        assertThat("hello-world-abc".findSubstring("HELLO-world", ignoreCase: true) == "hello-world")
+        assertThat("hello-world-abc".findSubstring("\\d+\\-\\d+", ignoreCase: false) == nil)
+    }
     
     func testTrimmedLeft() {
         assertThat("        How are you? ".trimmedLeft() == "How are you? ")

--- a/Example/Tests/StringExtensionTests.swift
+++ b/Example/Tests/StringExtensionTests.swift
@@ -73,6 +73,13 @@ class SwiftStringTests: XCTestCase {
         assertThat("hello".indexOf("lo"), presentAnd(equalTo(3)))
         assertThat("hello".indexOf("world"), nilValue())
     }
+
+    func testRindexOf() {
+        assertThat("hello".rindexOf("hell"), presentAnd(equalTo(0)))
+        assertThat("helloll".rindexOf("ll"), presentAnd(equalTo(5)))
+        assertThat("hellolloll".rindexOf("ll"), presentAnd(equalTo(8)))
+        assertThat("hello".rindexOf("world"), nilValue())
+    }
     
     func testInitials() {
         assertThat("First".initials() == "F")

--- a/Pod/Classes/StringExtensions.swift
+++ b/Pod/Classes/StringExtensions.swift
@@ -252,6 +252,24 @@ public extension String {
     func toDateTime(format: String = "yyyy-MM-dd HH:mm:ss") -> NSDate? {
         return toDate(format)
     }
+
+    func findSubstring(regexpStr: String, ignoreCase: Bool) -> String? {
+        var regExp: NSRegularExpression
+        if ignoreCase {
+            regExp = try! NSRegularExpression(pattern: regexpStr, options: .CaseInsensitive)
+        } else {
+            regExp = try! NSRegularExpression(pattern: regexpStr, options: NSRegularExpressionOptions(rawValue: 0))
+        }
+        
+        let matches = regExp.matchesInString(self, options: NSMatchingOptions(rawValue: 0), range: NSRange.init(location: 0, length: self.characters.count))
+        if matches.count > 0 {
+            let range = matches.first!.range
+            let result = self.substring(range.location, length: range.length)
+            return result
+        } else {
+            return nil
+        }
+    }
     
     func trimmedLeft() -> String {
         if let range = rangeOfCharacterFromSet(NSCharacterSet.whitespaceAndNewlineCharacterSet().invertedSet) {

--- a/Pod/Classes/StringExtensions.swift
+++ b/Pod/Classes/StringExtensions.swift
@@ -112,6 +112,13 @@ public extension String {
         }
         return nil
     }
+
+    func rindexOf(substring: String) -> Int? {
+        if let range = rangeOfString(substring, options: .BackwardsSearch) {
+            return startIndex.distanceTo(range.startIndex)
+        }
+        return nil
+    }
     
     func initials() -> String {
         let words = self.componentsSeparatedByString(" ")

--- a/README.md
+++ b/README.md
@@ -266,6 +266,13 @@ import SwiftString
 "2".toDouble() // 2.0
 ```
 
+**findSubstring()**
+```swift
+"hello-world-abc".findSubstring("\\w+\\-\\w+", ignoreCase: false)
+"hello-world-abc".findSubstring("HELLO-world", ignoreCase: true)
+"hello-world-abc".findSubstring("\\d+\\-\\d+", ignoreCase: false)
+```
+
 **trimmedLeft()**
 ```swift
 "        How are you? ".trimmedLeft() // "How are you? "

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ import SwiftString
 "hello".indexOf("world") // nil
 ```
 
+**rindexOf(substring)**
+```swift
+"hello".rindexOf("hell"), // 0
+"helloll".rindexOf("ll"), // 5
+"hello".rindexOf("world") // nil
+```
+
 **initials()**
 ```swift
 "First".initials(), // "F"


### PR DESCRIPTION
`rindexOf` is used to get the last occurrence of the given substring. It is a reverse version of `indexOf`.

Sample usage as below:
**rindexOf(substring)**

``` swift
"hello".rindexOf("hell"), // 0
"helloll".rindexOf("ll"), // 5
"hello".rindexOf("world") // nil
```

Test case for the new method is provided.
